### PR TITLE
feat: Implement notification system for high-severity findings

### DIFF
--- a/bounty_command_center/config.py
+++ b/bounty_command_center/config.py
@@ -37,6 +37,14 @@ class CeleryConfig(BaseModel):
     broker_url: str = "redis://localhost:6379/0"
     result_backend: str = "redis://localhost:6379/0"
 
+class NotificationConfig(BaseModel):
+    slack_webhook_url: str = ""
+    smtp_server: str = "localhost"
+    smtp_port: int = 1025
+    smtp_user: str = ""
+    smtp_password: str = ""
+    email_to: str = "your_email@example.com"
+
 class Settings(BaseModel):
     tools: ToolsConfig = ToolsConfig()
     api_keys: ApiKeysConfig = ApiKeysConfig()
@@ -44,6 +52,7 @@ class Settings(BaseModel):
     async_runner: AsyncRunnerConfig = AsyncRunnerConfig()
     auth: AuthConfig = AuthConfig()
     celery: CeleryConfig = CeleryConfig()
+    notifications: NotificationConfig = NotificationConfig()
 
 # --- Config Loading Logic ---
 

--- a/bounty_command_center/evidence_manager.py
+++ b/bounty_command_center/evidence_manager.py
@@ -1,6 +1,8 @@
 from typing import List, Optional, Dict, Any
 from sqlmodel import Session, select
 from .models import Evidence, Target
+from .notification_manager import NotificationManager
+from .config import settings
 
 class EvidenceManager:
     """Manages CRUD operations for evidence in the database."""
@@ -21,6 +23,14 @@ class EvidenceManager:
         db.add(new_evidence)
         db.commit()
         db.refresh(new_evidence)
+
+        if severity in ["High", "Critical"]:
+            notification_manager = NotificationManager()
+            notification_manager.send_high_severity_notification(
+                target_name=target.name,
+                finding_summary=new_evidence.finding_summary
+            )
+
         return new_evidence
 
     def get_evidence_by_id(self, db: Session, evidence_id: int) -> Optional[Evidence]:

--- a/bounty_command_center/notification_manager.py
+++ b/bounty_command_center/notification_manager.py
@@ -1,0 +1,62 @@
+import requests
+import smtplib
+from email.mime.text import MIMEText
+from .config import settings
+from .logging_setup import get_logger
+
+log = get_logger(__name__)
+
+class NotificationManager:
+    """Manages sending notifications for high-severity findings."""
+
+    def __init__(self):
+        self.slack_webhook_url = settings.notifications.slack_webhook_url
+        self.smtp_server = settings.notifications.smtp_server
+        self.smtp_port = settings.notifications.smtp_port
+        self.smtp_user = settings.notifications.smtp_user
+        self.smtp_password = settings.notifications.smtp_password
+        self.email_to = settings.notifications.email_to
+
+    def send_slack_notification(self, target_name: str, finding_summary: str):
+        """Sends a notification to a Slack webhook."""
+        if not self.slack_webhook_url:
+            log.warning("Slack webhook URL not configured. Skipping notification.")
+            return
+
+        message = {
+            "text": f"New high-severity finding detected!\n*Target:* {target_name}\n*Finding:* {finding_summary}"
+        }
+        try:
+            response = requests.post(self.slack_webhook_url, json=message)
+            response.raise_for_status()
+            log.info("Slack notification sent successfully.")
+        except requests.exceptions.RequestException as e:
+            log.error("Failed to send Slack notification.", error=str(e))
+
+    def send_email_notification(self, target_name: str, finding_summary: str):
+        """Sends an email notification."""
+        if not self.email_to:
+            log.warning("Email recipient not configured. Skipping notification.")
+            return
+
+        subject = f"New High-Severity Finding Detected: {target_name}"
+        body = f"A new high-severity finding has been detected for target: {target_name}.\n\nFinding: {finding_summary}"
+        msg = MIMEText(body)
+        msg["Subject"] = subject
+        msg["From"] = self.smtp_user
+        msg["To"] = self.email_to
+
+        try:
+            with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
+                if self.smtp_user and self.smtp_password:
+                    server.login(self.smtp_user, self.smtp_password)
+                server.sendmail(self.smtp_user, [self.email_to], msg.as_string())
+                log.info("Email notification sent successfully.")
+        except Exception as e:
+            log.error("Failed to send email notification.", error=str(e))
+
+    def send_high_severity_notification(self, target_name: str, finding_summary: str):
+        """Sends notifications for a high-severity finding."""
+        log.info("High-severity finding detected, sending notifications...")
+        self.send_slack_notification(target_name, finding_summary)
+        self.send_email_notification(target_name, finding_summary)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,107 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlmodel import Session, create_engine
+from bounty_command_center.models import Target, Evidence
+from bounty_command_center.evidence_manager import EvidenceManager
+
+# Create a new engine for the test database
+engine = create_engine("sqlite:///:memory:")
+
+@pytest.fixture(name="db_session")
+def db_session_fixture():
+    """Create a new database session for each test."""
+    from bounty_command_center.models import SQLModel
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    SQLModel.metadata.drop_all(engine)
+
+@patch("bounty_command_center.evidence_manager.NotificationManager")
+def test_create_evidence_sends_high_severity_notification(
+    mock_notification_manager, db_session: Session
+):
+    """
+    Test that a high-severity notification is sent when evidence with
+    severity "High" is created.
+    """
+    # Arrange
+    mock_manager_instance = mock_notification_manager.return_value
+    evidence_manager = EvidenceManager()
+    target = Target(name="Test Target", url="http://test.com", scope=["http://test.com"])
+    db_session.add(target)
+    db_session.commit()
+
+    # Act
+    evidence_manager.create_evidence(
+        db=db_session,
+        finding_summary="Test high-severity finding",
+        reproduction_steps="1. Do this\n2. Do that",
+        severity="High",
+        status="new",
+        target_id=target.id,
+    )
+
+    # Assert
+    mock_manager_instance.send_high_severity_notification.assert_called_once_with(
+        target_name="Test Target",
+        finding_summary="Test high-severity finding",
+    )
+
+@patch("bounty_command_center.evidence_manager.NotificationManager")
+def test_create_evidence_sends_critical_severity_notification(
+    mock_notification_manager, db_session: Session
+):
+    """
+    Test that a high-severity notification is sent when evidence with
+    severity "Critical" is created.
+    """
+    # Arrange
+    mock_manager_instance = mock_notification_manager.return_value
+    evidence_manager = EvidenceManager()
+    target = Target(name="Test Target", url="http://test.com", scope=["http://test.com"])
+    db_session.add(target)
+    db_session.commit()
+
+    # Act
+    evidence_manager.create_evidence(
+        db=db_session,
+        finding_summary="Test critical-severity finding",
+        reproduction_steps="1. Do this\n2. Do that",
+        severity="Critical",
+        status="new",
+        target_id=target.id,
+    )
+
+    # Assert
+    mock_manager_instance.send_high_severity_notification.assert_called_once_with(
+        target_name="Test Target",
+        finding_summary="Test critical-severity finding",
+    )
+
+@patch("bounty_command_center.evidence_manager.NotificationManager")
+def test_create_evidence_does_not_send_low_severity_notification(
+    mock_notification_manager, db_session: Session
+):
+    """
+    Test that a notification is not sent when evidence with a
+    low severity (e.g., "Informational") is created.
+    """
+    # Arrange
+    mock_manager_instance = mock_notification_manager.return_value
+    evidence_manager = EvidenceManager()
+    target = Target(name="Test Target", url="http://test.com", scope=["http://test.com"])
+    db_session.add(target)
+    db_session.commit()
+
+    # Act
+    evidence_manager.create_evidence(
+        db=db_session,
+        finding_summary="Test informational finding",
+        reproduction_steps="1. Do this\n2. Do that",
+        severity="Informational",
+        status="new",
+        target_id=target.id,
+    )
+
+    # Assert
+    mock_manager_instance.send_high_severity_notification.assert_not_called()


### PR DESCRIPTION
This commit introduces a notification system that sends a message to a Slack webhook and an email address when a new high-severity finding is detected.

The notification message includes the target name and the finding summary.

Changes include:
- Added a `NotificationConfig` model to `config.py` to store notification settings.
- Created a `NotificationManager` class in `notification_manager.py` to handle sending notifications.
- Updated `EvidenceManager` to trigger notifications when a new high-severity finding is created.
- Added tests to verify the notification logic.