### PR TITLE
feat: Add resource monitoring to scans

### DIFF
--- a/bounty_command_center/async_runner.py
+++ b/bounty_command_center/async_runner.py
@@ -1,6 +1,8 @@
 import asyncio
 from dataclasses import dataclass, asdict
 from .logging_setup import get_logger
+import psutil
+import time
 
 # A simple data class to structure the results of each command
 @dataclass
@@ -10,38 +12,104 @@ class CommandResult:
     stderr: str
     return_code: int | None
     timed_out: bool = False
+    aborted: bool = False
 
 class AsyncToolRunner:
     """
-    A class to run multiple shell commands asynchronously with timeouts.
+    A class to run multiple shell commands asynchronously with timeouts and resource monitoring.
     """
     def __init__(self):
         self.log = get_logger(self.__class__.__name__)
 
+    async def _monitor_resources(self, proc: asyncio.subprocess.Process, command_str: str) -> bool:
+        """
+        Monitors the resource usage of a process. If usage is too high for too long,
+        it kills the process.
+        Returns True if the process was aborted, False otherwise.
+        """
+        try:
+            p = psutil.Process(proc.pid)
+            # First call is to initialize, subsequent calls will have a meaningful value
+            p.cpu_percent(interval=None)
+
+            high_usage_start_time = None
+            CPU_THRESHOLD = 80.0
+            MEM_THRESHOLD = 75.0
+            TIME_LIMIT_SECONDS = 30
+
+            while proc.returncode is None:
+                await asyncio.sleep(1) # Check every second
+
+                if proc.returncode is not None:
+                    break
+
+                try:
+                    if not p.is_running():
+                        break
+
+                    cpu_percent = p.cpu_percent(interval=None)
+                    mem_percent = p.memory_percent()
+
+                    if cpu_percent > CPU_THRESHOLD or mem_percent > MEM_THRESHOLD:
+                        if high_usage_start_time is None:
+                            high_usage_start_time = time.time()
+                        elif time.time() - high_usage_start_time > TIME_LIMIT_SECONDS:
+                            self.log.warning(
+                                "Aborting command due to excessive resource usage",
+                                command=command_str,
+                                cpu_percent=cpu_percent,
+                                memory_percent=mem_percent,
+                            )
+                            p.kill()
+                            return True  # Aborted
+                    else:
+                        high_usage_start_time = None
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    break # Process ended before we could check it
+        except psutil.NoSuchProcess:
+            pass # Process finished before monitoring could start
+        except asyncio.CancelledError:
+            pass # Monitoring was cancelled, which is expected
+        except Exception as e:
+            self.log.error("An unexpected error occurred in resource monitor", error=str(e), command=command_str)
+
+        return False # Not aborted
+
     async def _run_single_command(self, command: list[str], timeout: int) -> CommandResult:
         """
-        Runs a single command asynchronously with a specified timeout.
+        Runs a single command asynchronously with a specified timeout and resource monitoring.
         """
         cmd_str = " ".join(command)
         log = self.log.bind(command=cmd_str, timeout=timeout)
         log.info("Starting command")
 
+        proc = None
+        monitor_task = None
+        aborted = False
+
         try:
-            # Create the subprocess
             proc = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE
             )
 
-            # Wait for the process to complete with a timeout
+            monitor_task = asyncio.create_task(self._monitor_resources(proc, cmd_str))
+
             stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
 
-            # Decode stdout and stderr
+            if monitor_task.done():
+                aborted = await monitor_task
+            else:
+                monitor_task.cancel()
+
             stdout = stdout_bytes.decode('utf-8', errors='ignore').strip()
             stderr = stderr_bytes.decode('utf-8', errors='ignore').strip()
 
-            if proc.returncode == 0:
+            if proc.returncode != 0 and aborted:
+                log.warning("Command was aborted due to excessive resource usage", stdout=stdout, stderr=stderr, return_code=proc.returncode)
+                stderr = f"Command aborted after exceeding resource limits (CPU > 80% or Memory > 75% for 30s)."
+            elif proc.returncode == 0:
                 log.info("Command finished successfully", stdout=stdout, stderr=stderr, return_code=proc.returncode)
             else:
                 log.warning("Command finished with an error", stdout=stdout, stderr=stderr, return_code=proc.returncode)
@@ -50,25 +118,25 @@ class AsyncToolRunner:
                 command=cmd_str,
                 stdout=stdout,
                 stderr=stderr,
-                return_code=proc.returncode
+                return_code=proc.returncode,
+                aborted=aborted,
             )
 
         except asyncio.TimeoutError:
             log.error("Command timed out")
-            # Attempt to clean up the process
-            if 'proc' in locals() and proc.returncode is None:
+            if proc and proc.returncode is None:
                 try:
                     proc.kill()
                     await proc.wait()
                 except ProcessLookupError:
-                    # Process might have finished just as timeout occurred
                     pass
             return CommandResult(
                 command=cmd_str,
                 stdout="",
                 stderr="Timeout occurred after {} seconds.".format(timeout),
                 return_code=None,
-                timed_out=True
+                timed_out=True,
+                aborted=False,
             )
         except FileNotFoundError:
             log.error("Command not found", command=command[0])
@@ -77,7 +145,7 @@ class AsyncToolRunner:
                 stdout="",
                 stderr=f"Command not found: {command[0]}",
                 return_code=None,
-                timed_out=False
+                aborted=False
             )
         except Exception as e:
             log.exception("An unexpected error occurred while running command")
@@ -86,8 +154,11 @@ class AsyncToolRunner:
                 stdout="",
                 stderr=str(e),
                 return_code=None,
-                timed_out=False
+                aborted=False,
             )
+        finally:
+            if monitor_task and not monitor_task.done():
+                monitor_task.cancel()
 
     async def run_commands(self, commands: list[list[str]], timeout: int) -> list[CommandResult]:
         """
@@ -97,12 +168,7 @@ class AsyncToolRunner:
             return []
 
         self.log.info("Starting a batch of commands", command_count=len(commands), timeout=timeout)
-
-        # Create a list of tasks to run concurrently
         tasks = [self._run_single_command(cmd, timeout) for cmd in commands]
-
-        # Wait for all tasks to complete
         results = await asyncio.gather(*tasks)
-
         self.log.info("Finished running batch of commands.")
         return results

--- a/bounty_command_center/dalfox_runner.py
+++ b/bounty_command_center/dalfox_runner.py
@@ -17,7 +17,14 @@ class DalfoxRunner(AsyncToolRunner):
         # Execute the command
         result = await self._run_single_command(command, timeout=600) # 10-minute timeout
 
-        if result.return_code == 0 and result.stdout:
+        if result.aborted:
+            self.log.warning(f"Dalfox scan for {target.url} was aborted due to excessive resource usage.")
+            return [Evidence(
+                finding_summary="Scan aborted due to excessive resource usage.",
+                severity="Informational",
+                target_id=target.id,
+            )]
+        elif result.return_code == 0 and result.stdout:
             # Parse the output and create evidence
             return self._parse_output(result.stdout, target)
         elif result.stderr:

--- a/bounty_command_center/sqlmap_runner.py
+++ b/bounty_command_center/sqlmap_runner.py
@@ -17,7 +17,14 @@ class SqlmapRunner(AsyncToolRunner):
         # Execute the command
         result = await self._run_single_command(command, timeout=900) # 15-minute timeout
 
-        if result.return_code == 0 and result.stdout:
+        if result.aborted:
+            self.log.warning(f"Sqlmap scan for {target.url} was aborted due to excessive resource usage.")
+            return [Evidence(
+                finding_summary="Scan aborted due to excessive resource usage.",
+                severity="Informational",
+                target_id=target.id,
+            )]
+        elif result.return_code == 0 and result.stdout:
             # Parse the output and create evidence
             return self._parse_output(result.stdout, target)
         elif result.stderr:

--- a/bounty_command_center/subfinder_runner.py
+++ b/bounty_command_center/subfinder_runner.py
@@ -17,7 +17,14 @@ class SubfinderRunner(AsyncToolRunner):
         # Execute the command
         result = await self._run_single_command(command, timeout=300) # 5-minute timeout
 
-        if result.return_code == 0 and result.stdout:
+        if result.aborted:
+            self.log.warning(f"Subfinder scan for {target.url} was aborted due to excessive resource usage.")
+            return [Evidence(
+                finding_summary="Scan aborted due to excessive resource usage.",
+                severity="Informational",
+                target_id=target.id,
+            )]
+        elif result.return_code == 0 and result.stdout:
             # Parse the output and create evidence
             return self._parse_output(result.stdout, target)
         elif result.stderr:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ typer
 rich
 celery
 redis
+psutil

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -80,3 +80,30 @@ async def test_sqlmap_runner(target):
     assert evidence_list[0].severity == "Critical"
     assert "Error-based" in evidence_list[1].finding_summary
     assert evidence_list[1].severity == "High"
+
+@pytest.mark.asyncio
+async def test_runner_aborted_scan(target):
+    """
+    Tests that a runner correctly handles an aborted scan.
+    """
+    runner = SubfinderRunner()  # We can use any runner for this test
+
+    # Mock the command result for an aborted scan
+    mock_result = CommandResult(
+        command="",
+        stdout="",
+        stderr="Aborted",
+        return_code=1,
+        aborted=True
+    )
+
+    # Patch the _run_single_command method
+    runner._run_single_command = AsyncMock(return_value=mock_result)
+
+    # Run the runner
+    evidence_list = await runner.run(target)
+
+    # Assertions
+    assert len(evidence_list) == 1
+    assert evidence_list[0].finding_summary == "Scan aborted due to excessive resource usage."
+    assert evidence_list[0].severity == "Informational"


### PR DESCRIPTION
This commit introduces resource monitoring for all scans run by the `AsyncToolRunner`.

- A new `_monitor_resources` coroutine is added to `async_runner.py` that uses `psutil` to track the CPU and memory usage of a running process.
- If a process's CPU usage exceeds 80% or its memory usage exceeds 75% for more than 30 seconds, the process is terminated.
- The `CommandResult` dataclass is updated with an `aborted` flag to indicate when a process has been terminated for this reason.
- The `SubfinderRunner`, `DalfoxRunner`, and `SqlmapRunner` classes are updated to handle the new `aborted` flag. When a scan is aborted, an `Evidence` object is created with a summary indicating that the scan was aborted due to excessive resource usage.
- `psutil` is added to `requirements.txt`.
- A new test is added to `tests/test_runners.py` to verify that aborted scans are handled correctly.