### PR TITLE
fix(deps): Add missing dependencies for testing and linting

### DIFF
--- a/web_requirements.txt
+++ b/web_requirements.txt
@@ -9,3 +9,5 @@ markdown
 markupsafe
 pytest
 httpx
+pytest-asyncio
+flake8


### PR DESCRIPTION
Add `pytest-asyncio` to support running asynchronous tests with pytest. This resolves the test failures related to `async def` functions.

Add `flake8` to support code quality linting, as requested in the initial verification steps.

These changes ensure that the local CI simulation (tests and linting) can run completely.