### PR TITLE
feat: Add push and pull_request triggers to workflow

### DIFF
--- a/.github/workflows/jules-full-scan.yml
+++ b/.github/workflows/jules-full-scan.yml
@@ -1,14 +1,19 @@
 name: Hardened Multi-Job Security Scan
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       target:
-        description: "Target domain or IP"
-        required: true
+        description: "Target domain or IP. Defaults to ziana-scan.bensalemyassine498.workers.dev on automated runs."
+        required: false
+        default: 'ziana-scan.bensalemyassine498.workers.dev'
       sev:
         description: "Minimum severity to report (low|medium|high|critical)"
-        required: true
+        required: false
         default: "medium"
   schedule:
     - cron: "0 */12 * * *"


### PR DESCRIPTION
This commit enhances the security scanning workflow by adding triggers for `push` and `pull_request` events on the `main` branch.

This change integrates the security scan directly into the development lifecycle, ensuring that code is automatically scanned upon being pushed or proposed for merging.

To support these non-interactive triggers, the `workflow_dispatch` inputs for `target` and `sev` have been made optional with sensible default values, preventing the workflow from failing during automated runs.